### PR TITLE
Implement basic WhatsApp webhook server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VERIFY_TOKEN=your_verify_token
+WHATSAPP_TOKEN=your_whatsapp_access_token
+PHONE_NUMBER_ID=your_phone_number_id

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/node_modules
+node_modules
+.env

--- a/messageHandling.js
+++ b/messageHandling.js
@@ -1,0 +1,34 @@
+const axios = require('axios');
+const { menuInicio, menuHoy, ofertasDia } = require('./whatsappTemplates');
+
+async function handleMessage(message) {
+  const from = message.from;
+  const text = message.text?.body?.toLowerCase() || '';
+
+  if (text === 'ver men\u00fa de hoy') {
+    try {
+      const { data } = await axios.get('http://127.0.0.1/rest/api/menu');
+      const platillos = Array.isArray(data) ? data : [];
+      await menuHoy(from, platillos);
+    } catch (err) {
+      console.error('Error fetching menu:', err.message);
+      await menuInicio(from);
+    }
+  } else if (text === 'ver ofertas del d\u00eda') {
+    try {
+      const { data } = await axios.get('http://127.0.0.1/rest/api/ofertas');
+      const ofertas = Array.isArray(data) ? data : [];
+      await ofertasDia(from, ofertas);
+    } catch (err) {
+      console.error('Error fetching ofertas:', err.message);
+      await menuInicio(from);
+    }
+  } else if (text === 'salir') {
+    // Could implement an exit option; for now, we just send menu again
+    await menuInicio(from);
+  } else {
+    await menuInicio(from);
+  }
+}
+
+module.exports = handleMessage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "express": "^4.21.2",
-        "mssql": "^11.0.1"
+        "mssql": "^11.0.1",
+        "dotenv": "^16.4.5"
       }
     },
     "node_modules/@azure-rest/core-client": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,16 @@
 {
+  "name": "rest-bot",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "axios": "^1.7.8",
     "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "express": "^4.21.2",
-    "mssql": "^11.0.1"
+    "mssql": "^11.0.1",
+    "dotenv": "^16.4.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+require('dotenv').config();
+const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
+const webhookVerification = require('./webhookVerification');
+const webhook = require('./webhook');
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+app.get('/webhook', webhookVerification);
+app.post('/webhook', webhook);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Webhook listening on port ${PORT}`));

--- a/webhook.js
+++ b/webhook.js
@@ -1,0 +1,19 @@
+const handleMessage = require('./messageHandling');
+
+module.exports = async function webhook(req, res) {
+  const body = req.body;
+
+  if (body.object) {
+    const entry = body.entry && body.entry[0];
+    const changes = entry && entry.changes && entry.changes[0];
+    const value = changes && changes.value;
+    const message = value && value.messages && value.messages[0];
+
+    if (message) {
+      await handleMessage(message);
+    }
+    res.sendStatus(200);
+  } else {
+    res.sendStatus(404);
+  }
+};

--- a/webhookVerification.js
+++ b/webhookVerification.js
@@ -1,0 +1,13 @@
+const VERIFY_TOKEN = process.env.VERIFY_TOKEN;
+
+module.exports = function webhookVerification(req, res) {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+
+  if (mode && token && mode === 'subscribe' && token === VERIFY_TOKEN) {
+    res.status(200).send(challenge);
+  } else {
+    res.sendStatus(403);
+  }
+};

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -1,0 +1,53 @@
+const axios = require('axios');
+
+const WHATSAPP_TOKEN = process.env.WHATSAPP_TOKEN;
+const PHONE_NUMBER_ID = process.env.PHONE_NUMBER_ID;
+const API_URL = `https://graph.facebook.com/v18.0/${PHONE_NUMBER_ID}/messages`;
+
+function sendTemplate(to, templateName, components = []) {
+  return axios.post(
+    API_URL,
+    {
+      messaging_product: 'whatsapp',
+      to,
+      type: 'template',
+      template: {
+        name: templateName,
+        language: { code: 'es_MX' },
+        components,
+      },
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${WHATSAPP_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+}
+
+function menuInicio(to) {
+  return sendTemplate(to, 'menu_inicio');
+}
+
+function menuHoy(to, platillos) {
+  const bodyText = platillos.join('\n');
+  return sendTemplate(to, 'menu_hoy', [
+    {
+      type: 'body',
+      parameters: [{ type: 'text', text: bodyText }],
+    },
+  ]);
+}
+
+function ofertasDia(to, ofertas) {
+  const bodyText = ofertas.join('\n');
+  return sendTemplate(to, 'ofertas_dia', [
+    {
+      type: 'body',
+      parameters: [{ type: 'text', text: bodyText }],
+    },
+  ]);
+}
+
+module.exports = { sendTemplate, menuInicio, menuHoy, ofertasDia };


### PR DESCRIPTION
## Summary
- setup Express server
- add WhatsApp webhook verification and handler
- create WhatsApp message handling logic
- define helper for WhatsApp templates
- provide environment sample and ignore `.env`

## Testing
- `node -c server.js`
- `node -c webhook.js`
- `node -c webhookVerification.js`
- `node -c messageHandling.js`
- `node -c whatsappTemplates.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6887c5d7ec18832ba59fe6dcd816ce97