### PR TITLE
Enable WhatsApp webhook message handling

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -1,33 +1,45 @@
 const axios = require('axios');
-const { menuInicio, menuHoy, ofertasDia } = require('./whatsappTemplates');
+const { sendTemplate, menuHoy, ofertasDia } = require('./whatsappTemplates');
 
-async function handleMessage(message) {
-  const from = message.from;
-  const text = message.text?.body?.toLowerCase() || '';
+async function handleMessage(phone_number_id, from, text) {
+  const normalizedText = (text || '').toLowerCase();
+  console.log('Mensaje recibido:', normalizedText, 'de:', from);
 
-  if (text === 'ver men\u00fa de hoy') {
+  const greetings = [
+    'hola',
+    'buen d\u00eda',
+    'buenas tardes',
+    'hey',
+    'saludos',
+    'qu\u00e9 tal',
+  ];
+
+  if (greetings.includes(normalizedText)) {
+    await sendTemplate(from, 'menu_inicio');
+    console.log('Respuesta enviada a', from);
+  } else if (normalizedText === 'ver men\u00fa de hoy') {
     try {
       const { data } = await axios.get('http://127.0.0.1/rest/api/menu');
       const platillos = Array.isArray(data) ? data : [];
       await menuHoy(from, platillos);
     } catch (err) {
       console.error('Error fetching menu:', err.message);
-      await menuInicio(from);
+      await sendTemplate(from, 'menu_inicio');
     }
-  } else if (text === 'ver ofertas del d\u00eda') {
+  } else if (normalizedText === 'ver ofertas del d\u00eda') {
     try {
       const { data } = await axios.get('http://127.0.0.1/rest/api/ofertas');
       const ofertas = Array.isArray(data) ? data : [];
       await ofertasDia(from, ofertas);
     } catch (err) {
       console.error('Error fetching ofertas:', err.message);
-      await menuInicio(from);
+      await sendTemplate(from, 'menu_inicio');
     }
-  } else if (text === 'salir') {
+  } else if (normalizedText === 'salir') {
     // Could implement an exit option; for now, we just send menu again
-    await menuInicio(from);
+    await sendTemplate(from, 'menu_inicio');
   } else {
-    await menuInicio(from);
+    await sendTemplate(from, 'menu_inicio');
   }
 }
 


### PR DESCRIPTION
## Summary
- create an express router for `/webhook` POST
- handle greetings and other text using `sendTemplate`
- log incoming messages and responses

## Testing
- `npm install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6887d7c43654832b96e563794d70aa95