### PR TITLE
Fix WhatsApp env token and webhook handling

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -1,5 +1,5 @@
-const axios = require('axios');
 require('dotenv').config();
+const axios = require('axios');
 
 const greetings = [
   'hola',
@@ -14,12 +14,12 @@ const greetings = [
 async function sendTemplate(phoneId, to, templateName, components = []) {
   const token = process.env.WHATSAPP_TOKEN;
   if (!token) {
-    console.warn('WHATSAPP_TOKEN no definido');
+    console.error('❌ WHATSAPP_TOKEN no definido');
     return;
   }
 
   console.log(`Enviando plantilla '${templateName}' a ${to}`);
-  const url = `https://graph.facebook.com/v18.0/${phoneId}/messages`;
+  const url = `https://graph.facebook.com/v22.0/${phoneId}/messages`;
 
   await axios.post(
     url,

--- a/webhook.js
+++ b/webhook.js
@@ -3,33 +3,32 @@ const router = express.Router();
 const handleMessage = require('./messageHandling');
 
 router.post('/', async (req, res) => {
-  const body = req.body;
+  try {
+    const body = req.body;
+    console.log(JSON.stringify(body, null, 2));
 
-  console.log(JSON.stringify(body, null, 2));
-
-  if (body.object) {
-    try {
+    if (body.object) {
       const entry = body.entry && body.entry[0];
       const changes = entry && entry.changes && entry.changes[0];
       const value = changes && changes.value;
       const message = value && value.messages && value.messages[0];
 
       if (message && message.text) {
-        const phoneNumberId = value?.metadata?.phone_number_id;
-        if (!phoneNumberId) {
+        const phone_number_id = value?.metadata?.phone_number_id;
+        console.log('📞 Enviando desde phone_number_id:', phone_number_id);
+        if (!phone_number_id) {
           console.warn('phone_number_id no encontrado en el webhook');
+        } else {
+          const from = message.from;
+          const text = message.text.body;
+          await handleMessage(phone_number_id, from, text);
         }
-        const from = message.from;
-        const text = message.text.body;
-        await handleMessage(phoneNumberId, from, text);
       }
-    } catch (err) {
-      console.error('Error al procesar el webhook:', err);
     }
-    res.sendStatus(200);
-  } else {
-    res.sendStatus(404);
+  } catch (err) {
+    console.error('❌ Error al enviar mensaje:', err);
   }
+  res.sendStatus(200);
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- load `.env` before anything else in `messageHandling.js`
- warn when `WHATSAPP_TOKEN` is missing
- send templates using v22 Meta API
- validate `phone_number_id` from the webhook
- always return `200` and log detailed errors

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6887e0ef3030832b87f598dc1278d543