### PR TITLE
Fix webhook and template sender

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require("dotenv").config();
 const axios = require('axios');
 const { sendTemplate } = require('./whatsappTemplates');
 
@@ -32,21 +32,24 @@ function ofertasDia(phoneId, to, ofertas) {
   ]);
 }
 
-async function handleMessage(phoneId, to, msgBody) {
-  if (!phoneId || !to || !msgBody) {
+async function handleMessage(phoneId, from, msgBody) {
+  if (!phoneId || !from || !msgBody) {
     console.warn('phoneId, to o msgBody no definidos');
     return;
   }
 
-  const normalized = String(msgBody).trim().toLowerCase();
+  const to = from.startsWith("521") ? from.replace("521", "52") : from;
+  console.log("📞 Número corregido para envío:", to);
 
-  console.log('📩 Mensaje recibido:', normalized, 'de', to);
+  const normalized = String(msgBody).trim().toLowerCase();
+  console.log("📥 Mensaje recibido:", normalized);
 
   const isGreeting = greetings.includes(normalized);
   console.log('¿Se detectó saludo?', isGreeting);
 
   if (isGreeting) {
     console.log('Enviando plantilla de saludo');
+    console.log("📤 Enviando plantilla 'menu_inicio'");
     await sendTemplate('menu_inicio', phoneId, to);
   } else if (normalized === 'ver men\u00fa de hoy') {
     try {
@@ -55,6 +58,7 @@ async function handleMessage(phoneId, to, msgBody) {
       await menuHoy(phoneId, to, platillos);
     } catch (err) {
       console.error('Error fetching menu:', err.message);
+      console.log("📤 Enviando plantilla 'menu_inicio'");
       await sendTemplate('menu_inicio', phoneId, to);
     }
   } else if (normalized === 'ver ofertas del d\u00eda') {
@@ -64,13 +68,16 @@ async function handleMessage(phoneId, to, msgBody) {
       await ofertasDia(phoneId, to, ofertas);
     } catch (err) {
       console.error('Error fetching ofertas:', err.message);
+      console.log("📤 Enviando plantilla 'menu_inicio'");
       await sendTemplate('menu_inicio', phoneId, to);
     }
   } else if (normalized === 'salir') {
     // Could implement an exit option; for now, we just send menu again
+    console.log("📤 Enviando plantilla 'menu_inicio'");
     await sendTemplate('menu_inicio', phoneId, to);
   } else {
     console.log('Enviando plantilla como fallback');
+    console.log("📤 Enviando plantilla 'menu_inicio'");
     await sendTemplate('menu_inicio', phoneId, to);
   }
 }

--- a/webhook.js
+++ b/webhook.js
@@ -4,9 +4,12 @@ const handleMessage = require('./messageHandling');
 
 router.post('/', async (req, res) => {
   try {
-    const body = req.body;
-    console.log(JSON.stringify(body, null, 2));
+    console.log(
+      "📨 Webhook recibido:",
+      JSON.stringify(req.body, null, 2)
+    );
 
+    const body = req.body;
     const entry = body?.entry?.[0];
     const change = entry?.changes?.[0];
     const value = change?.value;
@@ -16,8 +19,11 @@ router.post('/', async (req, res) => {
     const from = message?.from;
     const msgBody = message?.text?.body;
 
-    if (msgBody) {
-      console.log(`📩 Webhook message from ${from}: ${msgBody}`);
+    console.log("🆔 phoneId:", phoneId);
+    console.log("📱 from:", from);
+    console.log("💬 msgBody:", msgBody);
+
+    if (message?.type === "text" && phoneId && from && msgBody) {
       await handleMessage(phoneId, from, msgBody);
     }
   } catch (err) {

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -1,21 +1,27 @@
 const axios = require('axios');
 
-async function sendTemplate(templateName, phoneId, to, components = []) {
+async function sendTemplate(templateName, phoneId, to) {
   const token = process.env.WHATSAPP_TOKEN;
 
   if (!token) {
-    console.warn('⚠️  WHATSAPP_TOKEN no definido');
+    console.error('⚠️  WHATSAPP_TOKEN no definido');
     return;
   }
 
   if (!phoneId) {
-    console.warn('⚠️  phoneId no definido');
+    console.error('⚠️  phoneId no definido');
+    return;
+  }
+
+  if (!to) {
+    console.error('⚠️  to no definido');
     return;
   }
 
   const url = `https://graph.facebook.com/v23.0/${phoneId}/messages`;
 
   try {
+    console.log("🚀 Enviando plantilla:", templateName, "a", to);
     await axios.post(
       url,
       {
@@ -25,7 +31,7 @@ async function sendTemplate(templateName, phoneId, to, components = []) {
         template: {
           name: templateName,
           language: { code: 'es_MX' },
-          components,
+          components: [],
         },
       },
       {


### PR DESCRIPTION
## Summary
- log and normalize sender numbers before sending templates
- check that incoming messages are text and log webhook data
- improve template sending with validations and logging

## Testing
- `node --check messageHandling.js`
- `node --check webhook.js`
- `node --check whatsappTemplates.js`
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6888fd836c84832b850ee8351e8b91d8