### PR TITLE
Add detailed logging for webhook and templates

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -42,11 +42,9 @@ async function handleMessage(phoneId, from, msgBody) {
 
   const to = from.startsWith("521") ? from.replace("521", "52") : from;
 
-  console.log('📥 Mensaje recibido:', msgBody);
-  fs.appendFileSync('logs.txt', `📥 Mensaje recibido: ${msgBody}\n`);
-
-  console.log('📞 Enviando a:', to);
-  fs.appendFileSync('logs.txt', `📞 Enviando a: ${to}\n`);
+  const logMsg = `📥 Mensaje recibido: "${msgBody}" de ${from} → enviado a ${to}`;
+  console.log(logMsg);
+  fs.appendFileSync('logs.txt', logMsg + '\n');
 
   const normalized = String(msgBody).trim().toLowerCase();
 

--- a/webhook.js
+++ b/webhook.js
@@ -3,10 +3,23 @@ const fs = require('fs');
 const router = express.Router();
 const handleMessage = require('./messageHandling');
 
+// Meta validation endpoint
+router.get('/', (req, res) => {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+
+  const logEntry = `🧪 [GET webhook] mode: ${mode}, token: ${token}, challenge: ${challenge}`;
+  console.log(logEntry);
+  fs.appendFileSync('logs.txt', logEntry + '\n');
+
+  res.status(200).send(challenge);
+});
+
 router.post('/', async (req, res) => {
   try {
-    console.log('📨 Webhook recibido');
-    fs.appendFileSync('logs.txt', '📨 Webhook recibido\n');
+    console.log('📨 Webhook recibido:', JSON.stringify(req.body, null, 2));
+    fs.appendFileSync('logs.txt', '📨 Mensaje real recibido de WhatsApp\n' + JSON.stringify(req.body) + '\n');
 
     const body = req.body;
     const entry = body?.entry?.[0];

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -25,8 +25,9 @@ async function sendTemplate(templateName, phoneId, to) {
   const url = `https://graph.facebook.com/v23.0/${phoneId}/messages`;
 
   try {
-    console.log("🚀 Enviando plantilla:", templateName, "a", to);
-    fs.appendFileSync('logs.txt', `Enviando plantilla ${templateName} a ${to}\n`);
+    const logSend = `📤 Enviando plantilla "${templateName}" a ${to}`;
+    console.log(logSend);
+    fs.appendFileSync('logs.txt', logSend + '\n');
     await axios.post(
       url,
       {
@@ -48,9 +49,10 @@ async function sendTemplate(templateName, phoneId, to) {
     );
     console.log(`✅ Plantilla '${templateName}' enviada a ${to}`);
     fs.appendFileSync('logs.txt', `✅ Plantilla '${templateName}' enviada a ${to}\n`);
-  } catch (err) {
-    console.error('❌ Error enviando plantilla:', err.response?.data || err.message);
-    fs.appendFileSync('logs.txt', `Error enviando plantilla: ${err.response?.data || err.message}\n`);
+  } catch (error) {
+    console.error('❌ Error enviando plantilla:', error.response?.data || error.message);
+    const errLog = `❌ Error al enviar plantilla "${templateName}" a ${to}: ${error.message}`;
+    fs.appendFileSync('logs.txt', errLog + '\n');
   }
 }
 


### PR DESCRIPTION
## Summary
- log GET webhook validation in `webhook.js`
- save full webhook body to `logs.txt`
- log phone sanitization info in `messageHandling.js`
- track template sending and failures

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889087ce338832b85b9b98e36e28e4a