### PR TITLE
Fix msgBody extraction for interactive messages

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -28,7 +28,10 @@ router.post('/', async (req, res) => {
     const message = value?.messages?.[0];
     const phoneId = value?.metadata?.phone_number_id;
     const from = message?.from;
-    const msgBody = message?.text?.body;
+    let msgBody = message?.text?.body;
+    if (!msgBody && message?.interactive?.button_reply?.id) {
+      msgBody = message.interactive.button_reply.id;
+    }
 
     console.log('🆔 phoneId:', phoneId);
     console.log('📱 from:', from);


### PR DESCRIPTION
## Summary
- update webhook parsing logic to read button reply id when no text body is present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68891965fa7c832bb77e1002493e0547