### PR TITLE
Fix menu_hoy/offers handling with API validation

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -54,59 +54,77 @@ async function handleMessage(phoneId, from, msgBody) {
   } else if (normalized === 'menu_hoy') {
     try {
       const { data } = await axios.get(
-        'https://grp-ia.com/bitacora-residentes/ofertas.php'
+        "https://grp-ia.com/bitacora-residentes/ofertas.php"
       );
+
+      // 🪵 Log de depuración para ver qué trae el API
+      console.log("🪵 debug_get_log:", JSON.stringify(data, null, 2));
+
+      // Validación de estructura
+      if (!data || !Array.isArray(data.menu)) {
+        throw new Error("Formato inesperado: 'menu' no es arreglo o está ausente");
+      }
+
       const platillos = data.menu
         .map(item => `${item.nombre} $${item.precio}`)
-        .join(' | ');
+        .join(" | ");
 
-      await sendTemplate('menu_hoy', to, [
+      await sendTemplate("menu_hoy", to, [
         {
-          type: 'body',
+          type: "body",
           parameters: [
             {
-              type: 'text',
-              text: platillos,
-            },
-          ],
-        },
+              type: "text",
+              text: platillos
+            }
+          ]
+        }
       ]);
     } catch (err) {
-      console.error('❌ Error fetching menu:', err.message);
+      console.error("❌ Error fetching menu:", err.message);
       fs.appendFileSync(
-        'api_log.txt',
+        "api_log.txt",
         `❌ Error fetching menu: ${err.message}\n`
       );
-      await sendText(to, 'No pudimos consultar el menú en este momento.');
+      await sendText(to, "No pudimos consultar el menú en este momento.");
     }
     return;
   } else if (normalized === 'ofertas_dia') {
     try {
       const { data } = await axios.get(
-        'https://grp-ia.com/bitacora-residentes/ofertas.php'
+        "https://grp-ia.com/bitacora-residentes/ofertas.php"
       );
+
+      // 🪵 Log de depuración para ver qué trae el API
+      console.log("🪵 debug_get_log:", JSON.stringify(data, null, 2));
+
+      // Validación de estructura
+      if (!data || !Array.isArray(data.ofertas)) {
+        throw new Error("Formato inesperado: 'ofertas' no es arreglo o está ausente");
+      }
+
       const ofertas = data.ofertas
         .map(item => `${item.descripcion}`)
-        .join(' | ');
+        .join(" | ");
 
-      await sendTemplate('ofertas_dia', to, [
+      await sendTemplate("ofertas_dia", to, [
         {
-          type: 'body',
+          type: "body",
           parameters: [
             {
-              type: 'text',
-              text: ofertas,
-            },
-          ],
-        },
+              type: "text",
+              text: ofertas
+            }
+          ]
+        }
       ]);
     } catch (err) {
-      console.error('❌ Error fetching ofertas:', err.message);
+      console.error("❌ Error fetching ofertas:", err.message);
       fs.appendFileSync(
-        'api_log.txt',
+        "api_log.txt",
         `❌ Error fetching ofertas: ${err.message}\n`
       );
-      await sendText(to, 'No hay ofertas disponibles.');
+      await sendText(to, "No hay ofertas disponibles.");
     }
     return;
   } else if (normalized === 'salir') {

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const fs = require('fs');
 
-async function sendTemplate(templateName, to, components) {
+async function sendTemplate(templateName, to, components = []) {
   const token = process.env.WHATSAPP_TOKEN;
   const phoneId = process.env.PHONE_NUMBER_ID;
 


### PR DESCRIPTION
## Summary
- log API response and validate structure before processing menu
- handle ofertas_dia with same validation logic
- allow `sendTemplate` to accept dynamic components with a default parameter

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688951ff71dc832b840ba1979268d3aa