### PR TITLE
Improve WhatsApp template validation and add debug logs

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -43,12 +43,22 @@ async function handleIncomingMessage(message, phone) {
       switch (buttonId) {
         case 'ver_menu':
           const menuString = await getMenuItems();
-          await sendMenuHoy(phone, menuString);
+          console.log('[LOG] Menú generado:', menuString);
+          if (menuString && menuString.trim()) {
+            await sendMenuHoy(phone, menuString);
+          } else {
+            await sendTextMessage(phone, 'No hay menú disponible en este momento.');
+          }
           break;
 
         case 'ver_ofertas':
           const ofertasString = await getOfertas();
-          await sendOfertasDia(phone, ofertasString);
+          console.log('[LOG] Ofertas generadas:', ofertasString);
+          if (ofertasString && ofertasString.trim()) {
+            await sendOfertasDia(phone, ofertasString);
+          } else {
+            await sendTextMessage(phone, 'No hay ofertas disponibles en este momento.');
+          }
           break;
 
         case 'salir':

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -16,11 +16,21 @@ async function sendTemplateMessage(to, templateName, variableText = []) {
     },
   };
 
-  if (variableText.length > 0) {
+  // Validación y depuración
+  console.log(`[LOG] Enviando plantilla '${templateName}' con variables:`, variableText);
+
+  if (
+    Array.isArray(variableText) &&
+    variableText.length > 0 &&
+    variableText.every(text => typeof text === 'string' && text.trim() !== '')
+  ) {
     payload.template.components = [
       {
         type: 'body',
-        parameters: variableText.map(text => ({ type: 'text', text })),
+        parameters: variableText.map(text => ({
+          type: 'text',
+          text: text.trim(),
+        })),
       },
     ];
   }
@@ -30,7 +40,7 @@ async function sendTemplateMessage(to, templateName, variableText = []) {
       headers: { Authorization: `Bearer ${token}` },
     });
   } catch (error) {
-    console.error(`Error enviando template '${templateName}':`, error.response?.data || error.message);
+    console.error(`❌ Error enviando template '${templateName}':`, error.response?.data || error.message);
   }
 }
 


### PR DESCRIPTION
## Summary
- validate template variables before sending
- log template info and generated menu/offers
- avoid sending empty menu or offers messages

## Testing
- `node --check whatsappTemplates.js`
- `node --check messageHandling.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68898464eb04832b86e25dd46a3c1e09