### PR TITLE
Handle greetings with normalized body

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const handleIncomingMessage = require('./messageHandling');
+const { handleMessage, handleIncomingMessage } = require('./messageHandling');
 const verifyToken = process.env.VERIFY_TOKEN;
 
 // Ruta de verificación para Webhook
@@ -27,6 +27,10 @@ router.post('/', async (req, res) => {
         const phoneNumber = message?.from;
 
         if (message && phoneNumber) {
+          let msgBody = message.text?.body || '';
+          msgBody = msgBody?.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim();
+          console.log('📤 msgBody limpio:', msgBody);
+          await handleMessage(phoneNumber, msgBody);
           await handleIncomingMessage(message, phoneNumber);
         }
       });

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -46,16 +46,20 @@ async function sendTemplateMessage(to, templateName, variableText = []) {
 
 // Plantillas específicas
 
+function sendTemplate(to, templateName, variables = []) {
+  return sendTemplateMessage(to, templateName, variables);
+}
+
 function sendMenuInicio(to) {
-  return sendTemplateMessage(to, 'menu_inicio');
+  return sendTemplate(to, 'menu_inicio');
 }
 
 function sendMenuHoy(to, menuText) {
-  return sendTemplateMessage(to, 'menu_hoy', [menuText]);
+  return sendTemplate(to, 'menu_hoy', [menuText]);
 }
 
 function sendOfertasDia(to, ofertasText) {
-  return sendTemplateMessage(to, 'ofertas_dia', [ofertasText]);
+  return sendTemplate(to, 'ofertas_dia', [ofertasText]);
 }
 
 function sendTextMessage(to, bodyText) {
@@ -73,6 +77,7 @@ function sendTextMessage(to, bodyText) {
 }
 
 module.exports = {
+  sendTemplate,
   sendMenuInicio,
   sendMenuHoy,
   sendOfertasDia,


### PR DESCRIPTION
## Summary
- add `sendTemplate` helper
- support sanitized input and handle greeting keywords
- delegate text message processing through `handleMessage`
- send sanitized body to `handleMessage` in webhook

## Testing
- `node --version`
- `node --check webhook.js`
- `node --check messageHandling.js`
- `npm install --silent` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68899da0bee8832b990d82fdc3eaac4c