### PR TITLE
Add ofertas_dia template and handler

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -26,6 +26,23 @@ module.exports = async (req, res) => {
     const text = message.text?.body?.toLowerCase() || "";
     const buttonReply = message.interactive?.button_reply?.id?.toLowerCase() || "";
 
+    console.log("Mensaje recibido:", text);
+
+    if (text.includes("ofertas")) {
+      try {
+        const response = await axios.get("http://localhost:3000/api/ofertas");
+        const ofertas = response.data.ofertas || [];
+        if (ofertas.length === 0) throw new Error("Sin ofertas");
+
+        await templates["ofertas_dia"](from, ofertas);
+        console.log("Enviada plantilla ofertas_dia");
+      } catch (err) {
+        console.error("❌ Error al obtener ofertas:", err.message);
+        await enviarMensajeTexto(from, "No pudimos consultar las ofertas del día.");
+      }
+      return res.status(200).send("EVENT_RECEIVED");
+    }
+
     // Palabras clave
     const palabrasClaveSaludo = [
       "hola", "hi", "buen día", "buenos días", "hello", "qué tal", "buenas tardes",

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -8,6 +8,23 @@ const templates = {
   ERROR_GENERICO: "error_generico",
 };
 
+// Plantilla para ofertas del día
+templates["ofertas_dia"] = async (to, ofertas) => {
+  const formatted = ofertas.map((o) => `• ${o.descripcion}`).join("\n");
+  const components = [
+    {
+      type: "body",
+      parameters: [
+        {
+          type: "text",
+          text: formatted,
+        },
+      ],
+    },
+  ];
+  await enviarPayload(to, "ofertas_dia", components);
+};
+
 // Token de acceso generado en la consola de Meta
 
 const accessToken = "EAALCD9w1tyQBPNcZBxgrxbvJbn3qxyojxs55Mgu3z0Qlh3JzcHoOBLxED2vZCKiPqJefkZA1rDYEdlsIZBAynwMnLoq65yB1Y6EPkZB7BZAZCMtnqfewEGPZAkRsOb5y6AawvxAUIF4S3bH8wfsfgm4PBzMwIA3Ka2omjlomNLUAlVAbZBW2rmbnR0SSp9OzNCp7q7AZDZD";


### PR DESCRIPTION
## Summary
- add new template `ofertas_dia`
- respond to messages with `ofertas` keyword by requesting local API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a5dcb5858832b8c40414adc670ccd