### PR TITLE
Fix formatting for menu and offers templates

### DIFF
--- a/messageHandling.js
+++ b/messageHandling.js
@@ -103,8 +103,8 @@ async function handleOrdenMenu(from, extractedValue) {
     }
 
     fs.appendFileSync('api_log.txt', `${JSON.stringify(data)}\n`);
-    const platillos = data.menu.map(item => `${item.nombre} $${item.precio}`).join(' | ');
-    await enviarPlantillaMenu(from, platillos);
+    const platillos = data.menu;
+    await templates["menu_hoy"](from, platillos);
   } catch (err) {
     console.error('❌ Error fetching menu:', err.message);
     fs.appendFileSync('api_log.txt', `❌ Error fetching menu: ${err.message}\n`);
@@ -122,8 +122,8 @@ async function handleOrdenOferta(from, extractedValue) {
     }
 
     fs.appendFileSync('api_log.txt', `${JSON.stringify(data)}\n`);
-    const ofertas = data.ofertas.map(item => `${item.descripcion}`).join(' | ');
-    await enviarPlantillaOferta(from, ofertas);
+    const ofertas = data.ofertas;
+    await templates["ofertas_dia"](from, ofertas);
   } catch (err) {
     console.error('❌ Error fetching ofertas:', err.message);
     fs.appendFileSync('api_log.txt', `❌ Error fetching ofertas: ${err.message}\n`);

--- a/whatsappTemplates.js
+++ b/whatsappTemplates.js
@@ -8,18 +8,47 @@ const templates = {
   ERROR_GENERICO: "error_generico",
 };
 
-// Plantilla para ofertas del día
-templates["ofertas_dia"] = async (to, ofertas) => {
-  const formatted = ofertas.map((o) => `• ${o.descripcion}`).join("\n");
+// Utilidad para limpiar texto y asegurar longitud
+function sanitize(text) {
+  const cleaned = text.replace(/[\n\t]+/g, " ").replace(/\s{2,}/g, " ").trim();
+  return cleaned.slice(0, 1024);
+}
+
+// Plantilla para el menú del día
+templates["menu_hoy"] = async (to, menu) => {
+  const listado = menu
+    .map((p) => `${p.nombre} - $${Number(p.precio).toFixed(2)}`)
+    .join(" | ");
+  const bodyText = sanitize(
+    `Nos complace presentar el menú del día: ${listado} - Tokyo Sushi Prime`
+  );
   const components = [
     {
+      type: "header",
+      parameters: [{ type: "text", text: sanitize("Menú del día") }],
+    },
+    {
       type: "body",
-      parameters: [
-        {
-          type: "text",
-          text: formatted,
-        },
-      ],
+      parameters: [{ type: "text", text: bodyText }],
+    },
+  ];
+  await enviarPayload(to, templates.MENU_HOY, components);
+};
+
+// Plantilla para ofertas del día
+templates["ofertas_dia"] = async (to, ofertas) => {
+  const listado = ofertas.map((o) => o.descripcion).join(" | ");
+  const bodyText = sanitize(
+    `Nos complace mostrarte las ofertas del día: ${listado} - Tokyo Sushi Prime`
+  );
+  const components = [
+    {
+      type: "header",
+      parameters: [{ type: "text", text: sanitize("Ofertas disponibles") }],
+    },
+    {
+      type: "body",
+      parameters: [{ type: "text", text: bodyText }],
     },
   ];
   await enviarPayload(to, "ofertas_dia", components);


### PR DESCRIPTION
## Summary
- add sanitize helper and support header/body formatting
- create `templates.menu_hoy` and update `templates.ofertas_dia`
- call new template helpers from message handler

## Testing
- `node -c whatsappTemplates.js`
- `node -c messageHandling.js`


------
https://chatgpt.com/codex/tasks/task_e_688a6a01375c832babd93ec436a6d03d