### PR TITLE
Add universal webhook payload logging

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -1,8 +1,18 @@
 const express = require('express');
+const fs = require('fs');
 const messageHandling = require('./messageHandling');
 
 const router = express.Router();
 
-router.post('/', messageHandling);
+router.post('/', (req, res) => {
+  fs.appendFileSync(
+    'debug_payload_log.txt',
+    new Date().toISOString() +
+      ' - Payload Entrante: ' +
+      JSON.stringify(req.body, null, 2) +
+      '\n'
+  );
+  return messageHandling(req, res);
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- log every webhook payload to `debug_payload_log.txt` right when the POST handler receives it

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a74949a30832ba86cecd03e179941