### PR TITLE
Add webhook payload logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const webhookRoutes = require("./webhook");
 const app = express();
 const PORT =  3001;
 
+app.use(express.json());
 app.use(cors());
 app.use(bodyParser.json());
 

--- a/webhook.js
+++ b/webhook.js
@@ -5,6 +5,9 @@ const messageHandling = require('./messageHandling');
 const router = express.Router();
 
 router.post('/', (req, res) => {
+  const log = `${new Date().toISOString()} - Payload Entrante: ${JSON.stringify(req.body, null, 2)}\n`;
+  fs.appendFileSync('debug_payload_log.txt', log);
+  console.log('📩 Mensaje recibido en /webhook');
   try {
     fs.appendFileSync(
       'debug_payload_log.txt',


### PR DESCRIPTION
## Summary
- log and acknowledge incoming webhook events
- ensure JSON body parsing is enabled for all routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688accef3c98832bb227536fc516f3e8