### PR TITLE
Fix webhook handler and add logs directory

### DIFF
--- a/webhook.js
+++ b/webhook.js
@@ -1,33 +1,30 @@
-const express = require('express');
-const fs = require('fs');
-const handleIncomingMessage = require('./messageHandling');
+const fs = require("fs");
+const path = require("path");
+const router = require("express").Router();
+const handleIncomingMessage = require("./messageHandling");
 
-const router = express.Router();
-
-router.post('/webhook', async (req, res) => {
-  const body = req.body;
-  fs.appendFileSync(
-    'debug_payload_log.txt',
-    new Date().toISOString() + ' - Payload Entrante: ' + JSON.stringify(body, null, 2) + '\n'
-  );
 router.post("/webhook", async (req, res) => {
   const payload = req.body;
 
-  // Permite manejar ambos tipos de objetos
+  // 🪵 Log para diagnóstico
+  const logEntry = `${new Date().toISOString()} - WEBHOOK PAYLOAD: ${JSON.stringify(payload)}\n`;
+  fs.appendFileSync(path.join(__dirname, "logs", "api_log.txt"), logEntry);
+
+  // Procesar si es de tipo válido
   if (
-    payload.object === "whatsapp" ||
-    payload.object === "whatsapp_business_account"
+    payload?.object === "whatsapp" ||
+    payload?.object === "whatsapp_business_account"
   ) {
     try {
       await handleIncomingMessage(payload);
     } catch (err) {
       console.error("❌ Error en handleIncomingMessage:", err);
     }
+  } else {
+    console.warn("⚠️ Payload ignorado: tipo no válido:", payload?.object);
   }
 
   res.sendStatus(200);
-});
-
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- refactor webhook.js using Express router
- add persistent logging and handle multiple webhook types
- ensure logs folder exists via `.gitkeep`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688af381d800832ba6a629052067c811